### PR TITLE
carousel mvp update 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #DMD Section
 /client/assets/img/shoot
+/client/assets/img/shoot2
 ############
 
 # Logs

--- a/client/components/genericWidgets/flexCarousel/flexCarousel.js
+++ b/client/components/genericWidgets/flexCarousel/flexCarousel.js
@@ -4,6 +4,8 @@ async function buildCarousel(params){
   var options = params.options || {
 
   }
+  target.empty()
+
   console.log(imagePaths)
   var carouselHTML = $("#cargoHold > .flexCarousel").clone()
   imagePaths.forEach((x, i) => {

--- a/client/pages/darkRoom/darkRoom.html
+++ b/client/pages/darkRoom/darkRoom.html
@@ -1,7 +1,7 @@
 <span id="darkRoomMain" class="cols">
   <span id="selectShoot">
-    <span>Whitney Plantation Trip<br />2020-07-31</span>
-    <span>Hurricane Laura<br />2020-08-27</span>
+    <span onclick="cDI.pages.darkRoom.setGallery('shoot')">Whitney Plantation Trip<br />2020-07-31</span>
+    <span onclick="cDI.pages.darkRoom.setGallery('shoot2')">Hurricane Laura<br />2020-08-27</span>
   </span>
   <span class="carousel"></span>
 </span>

--- a/client/pages/darkRoom/darkRoom.js
+++ b/client/pages/darkRoom/darkRoom.js
@@ -1,7 +1,8 @@
 cDI.pages.darkRoom = {
   siteHeaderText: "Dark Room",
-  init: async () => {
+  setGallery: (folder) => {
     var imgs = []
+    if (folder == "shoot"){
     imgs.push("img/shoot/tiny1jpg.jpg")
     imgs.push("img/shoot/tiny2jpg.jpg")
     imgs.push("img/shoot/tiny3jpg.jpg")
@@ -12,6 +13,19 @@ cDI.pages.darkRoom = {
     imgs.push("img/shoot/tiny8jpg.jpg")
     imgs.push("img/shoot/tiny9jpg.jpg")
     imgs.push("img/shoot/tiny10jpg.jpg")
+    }
+    else if (folder == "shoot2") {
+      imgs.push("img/shoot2/hl1.jpg")
+      imgs.push("img/shoot2/hl2.jpg")
+      imgs.push("img/shoot2/hl3.jpg")
+      imgs.push("img/shoot2/hl4.jpg")
+      imgs.push("img/shoot2/hl5.jpg")
+      imgs.push("img/shoot2/hl6.jpg")
+    }
     buildCarousel({ target: $(".carousel"), imagePaths: imgs })
   }
+
+}
+cDI.pages.darkRoom.init = () => {
+  cDI.pages.darkRoom.setGallery("shoot")
 }


### PR DESCRIPTION
- added new shoot to gitignore
- carousel can now have it's gallery switched by clicking on the name of the shoot

NEXT UP:
back to adding a new recipe