### PR TITLE
awaitable inputs update

### DIFF
--- a/client/components/big5/unitTests/unitTests.js
+++ b/client/components/big5/unitTests/unitTests.js
@@ -1,9 +1,28 @@
 cDI.components.unitTests = {
+  init: async () => {
+    var unitTestLevel = cDI.config.unitTest
+    if (unitTestLevel == 1){
+      console.log("Unit tests set to level 1: run all")
+      await cDI.components.unitTests.runAllUnitTests()
+    }
+    else if (unitTestLevel == 2){
+      console.log("Unit tests set to level 2: custom dev scenario")
+      await cDI.components.unitTests.customDevScenario()
+    }
+    else if (unitTestLevel == 3){
+      console.log("Unit tests set to level 3: just login if the session has expired")
+      await cDI.components.unitTests.loginIfNeccessary()
+    }
+  },
   customDevScenario: async () => {
     console.log("UT: Running custom dev scenario")
     await cDI.components.unitTests.loginIfNeccessary()
-    //await cDI.clickRes($(".recipeEdit"))
-    //$(".txtIngFood.Ing1").click()
+
+    var editButton = $("[data-rid='#45:0']").find(".recipeEdit")
+    await cDI.awaitableInput("click", editButton)
+
+    var searchSelectPane = await cDI.awaitableInput("click", $(".txtIngFood.Ing1"))
+    await cDI.awaitableInput("click", searchSelectPane.find(".option0"))
   },
   loginIfNeccessary: async () => {
     //if not logged in, use debugConf set in bootstrap to set an impersonate
@@ -18,21 +37,6 @@ cDI.components.unitTests = {
     await runAllAuth()
   }
 }
-cDI.components.unitTests.init = async () => {
-  var unitTestLevel = cDI.config.unitTest
-  if (unitTestLevel == 1){
-    console.log("Unit tests set to level 1: run all")
-    await cDI.components.unitTests.runAllUnitTests()
-  }
-  else if (unitTestLevel == 2){
-    console.log("Unit tests set to level 2: custom dev scenario")
-    await cDI.components.unitTests.customDevScenario()
-  }
-  else if (unitTestLevel == 3){
-    console.log("Unit tests set to level 3: just login if the session has expired")
-    await cDI.components.unitTests.loginIfNeccessary()
-  }
-}
 
   //#region permanent tests/
     //#region auth tests
@@ -42,11 +46,11 @@ cDI.components.unitTests.init = async () => {
       await utAuth_Login()
     }
     async function utAuth_clickAuthIcon(){
-      await cDI.clickRes($("#iconAuth"))
+      await cDI.awaitableInput("click", $("#iconAuth"))
     }
     async function utAuth_Signup(){
       console.log('UT: auth signup')
-      await cDI.clickRes($(".iconAuth"))
+      await cDI.awaitableInput("click", $(".iconAuth"))
       var randomId = "utAuthUser_" + await cDI.randomString(12)
       $("#txtSgnUN").val(randomId)
       $("#txtSgnPW").val("testpass")
@@ -73,11 +77,11 @@ cDI.components.unitTests.init = async () => {
       }
     }
     async function utAuth_Login(){
-      await cDI.clickRes($("#authBox"))
+      await cDI.awaitableInput("click", $("#authBox"))
       console.log("UT: logging in")
       $("#txtLoginUN").val(cDI.config.user.username)
       $("#txtLoginPW").val(cDI.config.user.password)
-      await cDI.clickRes($("#btnLogin"))
+      await cDI.awaitableInput("click", $("#btnLogin"))
     }
     //#endregion
 

--- a/client/components/genericWidgets/auth/auth.html
+++ b/client/components/genericWidgets/auth/auth.html
@@ -20,7 +20,7 @@
   } */
 </style>
 <script type="text/javascript">
-  cDI.addAsyncOnclick($("#btnSignup"), async (res) => {
+  cDI.addAwaitableInput("click", $("#btnSignup"), async (res) => {
     var email = $('#txtSgnEmail').val()
     var un = $('#txtSgnUN').val()
     var dn = $('#txtSgnDisplayName').val()
@@ -40,7 +40,7 @@
   })
 
   //add login function to button
-  cDI.addAsyncOnclick($("#btnLogin"), async (res) => {
+  cDI.addAwaitableInput("click", $("#btnLogin"), async (res) => {
     var un = $('#txtLoginUN').val()
     var pw = $('#txtLoginPW').val()
     var callRes = await cDI.remote.remoteCall("/login", {"username": un, "password": pw })

--- a/client/components/genericWidgets/modal/modal.html
+++ b/client/components/genericWidgets/modal/modal.html
@@ -65,7 +65,7 @@
     content.addClass("max")
   }
   cDI.widgets.modal.clickToModal = async (elem, dialogPath, fn, maximizeDialog = false) => {
-    await cDI.addAsyncOnclick(elem, async (e) => {
+    await cDI.addAwaitableInput("click", elem, async (e) => {
       var content = await cDI.remote.asyncGet(dialogPath)
       var modalElements = await cDI.widgets.modal.drawCurtain({ content: content, maximizeDialog: maximizeDialog })
       if (cDI.utils.isDef(fn)) { await fn(modalElements) }

--- a/client/components/genericWidgets/router/router.js
+++ b/client/components/genericWidgets/router/router.js
@@ -1,4 +1,12 @@
 cDI.components.router = {
+  init: async () => {
+    if (window.location.pathname.length == 1) {
+      await cDI.components.router.getRoute("blog")
+    }
+    else {
+      await cDI.components.router.getRoute(window.location.pathname)
+    }
+  },
   getRoute: async (path) => {
     if (path[0] == "/" || path[0] == "\\"){
       path = path.substr(1)
@@ -6,14 +14,6 @@ cDI.components.router = {
     window.history.pushState(null, null, path);
     var DIobj = await cDI.components.contentMain.loadPage(path)
     cDI.components.header.setHeaderText(DIobj.siteHeaderText)
-  }
-}
-cDI.components.router.init = async () => {
-  if (window.location.pathname.length == 1) {
-    await cDI.components.router.getRoute("blog")
-  }
-  else {
-    await cDI.components.router.getRoute(window.location.pathname)
   }
 }
 

--- a/scripts/!quickStartWin/3.2-startServer.bat
+++ b/scripts/!quickStartWin/3.2-startServer.bat
@@ -1,4 +1,4 @@
+@echo off
 ECHO Starting CodefortheFences server
 cd c:/node/codeforthefences/server/
 npm start
-$host.enternestedprompt()


### PR DESCRIPTION
- addAsyncOnclick is now generic for any .on() keywords
- debounce, addAwaitableInput, and awaitableInput now all return the final result of their delayed actions
- unit tests can now wait for debounced actions like searching
- searchSelect passes out it's pane if awaitableInput is used to create the searchSelect
- searchSelect now passes out the selection to data-searchselectrecord on the target input
- abstracted filling the ingredients and steps panes
- added data-editedrecipe to card when editing
- stubbed out acceptIngChange

NEXT UP:
- update ingredient references in steps when ingredient inputs change
- send editedRecipe to a route on save