### PR TITLE
reload step pane on ingredient change

### DIFF
--- a/client/assets/js/cDI.js
+++ b/client/assets/js/cDI.js
@@ -214,7 +214,11 @@ cDI.sequencer.debounce = async (key, fn, delay) => {
   var existing = cDI.sequencer.debounceFuncs.filter(x => x.key == key)[0]
   if (existing) {
     clearTimeout(existing.fn)
-    existing.fn = setTimeout(fn, delay)
+    return new Promise((fulfill, reject) => {
+      existing.fn = setTimeout(async () => {
+                      fulfill(await fn())
+                    }, delay)
+    })
   }
   else {
     return new Promise((fulfill, reject) => {

--- a/client/assets/js/services/recipeService.js
+++ b/client/assets/js/services/recipeService.js
@@ -3,12 +3,18 @@ cDI.services.recipe = {
     var callRes = await cDI.remote.remoteCall("/crud/recipe/r/", { expectMany: true })
     return cDI.utils.extrudeFlatGraph(callRes.payload, "recipe")
   },
+  parsePieces: (recipe) => {
+    var ingredients = recipe.recipeIngredient.sort((a, b) => a.ingredientNum < b.ingredientNum).map(x => x.ingredient)
+    var tools = recipe.recipeTool.sort((a, b) => a.toolNum < b.toolNum).map(x => x.tool)
+    var steps = recipe.recipeStep.sort((a, b) => a.stepNum < b.stepNum).map(x => x.step)
+    return { ingredients: ingredients, tools: tools, steps: steps }
+  },
   searchUoM: async () => {
-    var foo = await cDI.remote.remoteCall("/crud/UoM/r/")
-    console.log(foo)
+    var res = await cDI.remote.remoteCall("/crud/UoM/r/")
+    console.log(res)
   },
   save: async (recipe) => {
-    var foo = await cDI.remote.remoteCall("/crud/recipe/u/")
-    console.log(foo)
+    var res = await cDI.remote.remoteCall("/crud/recipe/u/", { recipe: recipe })
+    console.log(res)
   }
 }

--- a/client/components/big5/unitTests/unitTests.js
+++ b/client/components/big5/unitTests/unitTests.js
@@ -22,7 +22,8 @@ cDI.components.unitTests = {
     await cDI.awaitableInput("click", editButton)
 
     var searchSelectPane = await cDI.awaitableInput("click", $(".txtIngFood.Ing1"))
-    await cDI.awaitableInput("click", searchSelectPane.find(".option0"))
+    await cDI.awaitableInput("click", searchSelectPane.find(".btnClearInput"))
+    await cDI.awaitableInput("click", searchSelectPane.find(".option1"))
   },
   loginIfNeccessary: async () => {
     //if not logged in, use debugConf set in bootstrap to set an impersonate

--- a/client/components/genericWidgets/searchSelect/searchSelect.js
+++ b/client/components/genericWidgets/searchSelect/searchSelect.js
@@ -14,7 +14,7 @@ cDI.components.searchSelect = {
     tempInput.addClass("searchSelectInputTemp")
     tempInput.focus()
 
-    inputContainer.find(".btnClearInput").on("click", () => { cDI.components.searchSelect.clear(tempInput) })
+    cDI.addAwaitableInput("click", inputContainer.find(".btnClearInput"), async () => { return await cDI.components.searchSelect.clear(tempInput) })
 
     cDI.components.drawerPane.openDrawerPane(pane)
 
@@ -48,7 +48,7 @@ cDI.components.searchSelect = {
   },
   clear: async (input) => {
     input.val("")
-    input.trigger("keyup")
+    return await cDI.awaitableInput("keyup", input)
   },
   close: async(tempInput, target) => {
     cDI.components.drawerPane.closeDrawerPane($(tempInput).parent())

--- a/server/routes.js
+++ b/server/routes.js
@@ -115,6 +115,9 @@ module.exports = async (DI) => {
       succeed(res, data)
     }))
     router.post('/crud/recipe/u/', asyncRoute(async (req, res, next) => {
+      if (req.body.recipe){
+        console.log(req.body.recipe)
+      }
       succeed(res, "reached /crud/recipe/u/")
     }))
     router.post('/crud/UoM/r/', asyncRoute(async (req, res, next) => {


### PR DESCRIPTION
- debounce now returns the promise when the debounce resets the timer
- added recipeService function for pulling recipe ingredients, tools, and steps into an object
- made searchSelect clear button an async input (unit test can now cause searchSelect, clear it, and select from the resultSet)
- generalized createStepPane
- saving recipe edits hits route and logs the full edited recipe
- changing an ingredient food type will reload the step pane and fill in the edited recipe ingredients

NEXT UP:
- parse edited recipe on server and save changes to food type