### PR TITLE
mysql update 5

### DIFF
--- a/client/assets/js/cDI.js
+++ b/client/assets/js/cDI.js
@@ -187,7 +187,7 @@ cDI.remote.loadComponent = async (elem, folderPath, componentName, placement = 1
   if (placement == 0) { elem.prepend(html) }
   else if (placement == 1) { elem.append(html) }
 
-  ftbLog(`loading ${path}`)
+  ftbLogDev(`loading ${path}`)
   var DI = cDI.utils.getDIByCIName(componentName)
   if (DI.init) {
     await DI.init()
@@ -201,7 +201,7 @@ cDI.remote.loadComponent = async (elem, folderPath, componentName, placement = 1
 
 //#region logging
 cDI.logging = {
-  log: (message, data = null, levelOfMessage = 1, trace = false, callbackFn = null) => {
+  log: async (message, data = null, levelOfMessage = 1, trace = false, callbackFn = null) => {
     async function send(msg, obj, trace, fn) {
       cDI.logging.ifTrace(`${cDI.logging.tabSize}${msg}`, obj, trace)()
 
@@ -229,9 +229,9 @@ cDI.logging = {
       tmpDebugMode -= 1
     }
 
-    if (levelOfMessage == 1 && allowDev) { send(message, data, trace, callbackFn) }
-    else if (levelOfMessage == 2 && allowVerbose) { send(message, data, trace, callbackFn) }
-    else if (levelOfMessage == 4 && allowAJAX) { send(message, data, trace, callbackFn) }
+    if (levelOfMessage == 1 && allowDev) { await send(message, data, trace, callbackFn) }
+    else if (levelOfMessage == 2 && allowVerbose) { await send(message, data, trace, callbackFn) }
+    else if (levelOfMessage == 4 && allowAJAX) { await send(message, data, trace, callbackFn) }
   },
   ifTrace: (msg, data = null, trace = false) => {
     if (trace) {
@@ -252,8 +252,8 @@ cDI.logging = {
 //#region async inputs
 cDI.addAwaitableInput = async (inputType, elem, fn, trace = false, debounce = true) => {
   await elem.on(inputType, async (e) => {
-    ftbLog(`${inputType} occurred on elem: `, $(elem), 2, trace)
-    ftbLog(`result is: `, $(data), 2, trace)
+    ftbLogDev(`${inputType} occurred on elem: `, $(elem), 2, trace)
+    ftbLogDev(`result is: `, $(data), 2, trace)
     var data = await fn(e)
     return data
   })
@@ -311,4 +311,14 @@ cDI.session = {
 var ftbLog = cDI.logging.log
 var ftbIndent = cDI.logging.indent
 var ftbOutdent = cDI.logging.outdent
+var ftbLogDev = (() => {
+  return async (message, data = null, trace = false, callbackFn = null) => {
+    await ftbLog(message, data, 1, trace, callbackFn)
+  }
+})()
+var ftbLogUT = (() => {
+  return async (message, data = null, trace = false, callbackFn = null) => {
+    await ftbLog(message, data, 2, trace, callbackFn)
+  }
+})()
 //#endregion

--- a/client/components/big5/unitTests/auth/utAuth.js
+++ b/client/components/big5/unitTests/auth/utAuth.js
@@ -1,13 +1,13 @@
 cDI.components.unitTests.auth = {
   runAllAuth: async () => {
     ftbIndent()
-    ftbLog('UT: runAllAuth')
+    ftbLogUT('UT: runAllAuth')
     ftbIndent()
     await cDI.components.unitTests.auth.signup()
     await cDI.components.unitTests.auth.failCreateExistingUser()
     await cDI.components.unitTests.auth.login()
     ftbOutdent()
-    ftbLog('UT: runAllAuth passed')
+    ftbLogUT('UT: runAllAuth passed')
     ftbOutdent()
   },
   clickAuthIcon: async () => { return await cDI.awaitableInput("click", $("#authBox")) },
@@ -19,18 +19,18 @@ cDI.components.unitTests.auth = {
     $("#txtSgnConfPW").val("testpass")
   },
   signup: async () => {
-    ftbLog('UT: auth - 1. signup')
+    ftbLogUT('UT: auth - 1. signup')
     await cDI.session.logout()
     await cDI.components.unitTests.auth.clickAuthIcon()
     var randomId = "utAuthUser_" + await cDI.utils.randomString(12)
     await cDI.components.unitTests.auth.setSignupVals(randomId)
     await cDI.awaitableInput("click", $("#btnSignup"))
 
-    if (cDI.session.username == randomId){ ftbLog("UT: auth - signup passed") }
-    else { ftbLog("UT: auth - signup failed") }
+    if (cDI.session.username == randomId){ ftbLogUT("passed") }
+    else { ftbLogUT("UT: auth - signup failed") }
   },
   failCreateExistingUser: async () => {
-    ftbLog('UT: auth - 2. failCreateExistingUser')
+    ftbLogUT('UT: auth - 2. failCreateExistingUser')
     await cDI.session.logout()
     var errStr = "Unable to create new user, username is taken."
 
@@ -48,20 +48,20 @@ cDI.components.unitTests.auth = {
       secondSignup = await cDI.components.unitTests.auth.clickSignup()
     }
 
-    if (firstSignup == errStr || secondSignup == errStr) { ftbLog('UT: auth - failCreateExistingUser passed') }
+    if (firstSignup == errStr || secondSignup == errStr) { ftbLogUT('passed') }
     else {
-      ftbLog('UT: auth - failCreateExistingUser failed')
+      ftbLogUT('UT: auth - failCreateExistingUser failed')
     }
   },
   login: async () => {
-    ftbLog("UT: auth - 3. login")
+    ftbLogUT("UT: auth - 3. login")
     await cDI.session.logout()
     await cDI.components.unitTests.auth.clickAuthIcon()
     $("#txtLoginUN").val(cDI.config.user.username)
     $("#txtLoginPW").val(cDI.config.user.password)
     await cDI.components.unitTests.auth.clickLogin()
 
-    if (cDI.session.username == cDI.config.user.username){ ftbLog("UT: auth - login passed") }
-    else { ftbLog("UT: auth - login failed") }
+    if (cDI.session.username == cDI.config.user.username){ ftbLogUT("passed") }
+    else { ftbLogUT("UT: auth - login failed") }
   }
 }

--- a/client/components/big5/unitTests/unitTests.js
+++ b/client/components/big5/unitTests/unitTests.js
@@ -6,23 +6,23 @@ cDI.components.unitTests = {
     if (unitTestLevel != 0){
       await cDI.remote.asyncGetScript("/components/big5/unitTests/auth/utAuth.js")
       await cDI.remote.asyncGetScript("/components/big5/unitTests/recipe/utRecipe.js")
-      if (currDebugMode == 0) { cDI.config.debugMode = 1 }
+      if ([0, 1, 4, 5].indexOf(currDebugMode) != -1) { cDI.config.debugMode = 2 }
     }
 
     if (unitTestLevel == 1){
-      ftbLog("Unit tests set to level 1: run all")
+      ftbLogUT("Unit tests set to level 1: run all")
       ftbIndent()
       await cDI.components.unitTests.runAllUnitTests()
       ftbOutdent()
     }
     else if (unitTestLevel == 2){
-      ftbLog("Unit tests set to level 2: custom dev scenario")
+      ftbLogUT("Unit tests set to level 2: custom dev scenario")
       ftbIndent()
       await cDI.components.unitTests.customDevScenario()
       ftbOutdent()
     }
     else if (unitTestLevel == 3){
-      ftbLog("Unit tests set to level 3: just login if the session has expired")
+      ftbLogUT("Unit tests set to level 3: just login if the session has expired")
       ftbIndent()
       await cDI.components.unitTests.loginIfNeccessary()
       ftbOutdent()
@@ -31,24 +31,36 @@ cDI.components.unitTests = {
     cDI.config.debugMode = currDebugMode
   },
   customDevScenario: async () => {
-    ftbLog("UT: customDevScenario")
     await cDI.components.unitTests.loginIfNeccessary()
+    ftbLogUT("UT: customDevScenario")
 
     await cDI.components.unitTests.auth.runAllAuth()
     // await cDI.components.unitTests.recipe.runAllEditRecipe()
   },
   loginIfNeccessary: async () => {
-    ftbLog("UT: loginIfNeccessary")
+    ftbLogUT("UT: loginIfNeccessary")
+    ftbIndent()
     //if not logged in, use debugConf set in bootstrap to set an impersonate
     if (!cDI.utils.isDef(cDI.session.token)) {
-      ftbLog(`Not logged in, logging with ${cDI.config.user.username} and ${cDI.config.user.password}`)
+      ftbLogUT(`Not logged in, logging with ${cDI.config.user.username} and ${cDI.config.user.password}`)
       await cDI.components.unitTests.auth.login()
+      ftbLogUT(`login succeeded token: ${cDI.session.token.substr(0, 5)}...`)
     }
     //if we think we're logged in, verify by making a call. Triggers an implicit logout in the remoteCall func if call result has status "e".
-    else { await cDI.remote.remoteCall("/user/testToken") }
+    else {
+      ftbLogUT(`active session detected, testing`)
+      var sessionTest = await cDI.remote.remoteCall("/user/testToken")
+      if (sessionTest.status == 's'){
+        ftbLogUT(`active session still valid, proceeding: ${cDI.session.token.substr(0, 5)}...`)
+      }
+      else {
+      ftbLogUT(`error logging in`)
+      }
+    }
+    ftbOutdent()
   },
   runAllUnitTests: async () => {
-    ftbLog("UT: runAllUnitTests")
+    ftbLogUT("UT: runAllUnitTests")
     await cDI.components.unitTests.auth.runAllAuth()
     await cDI.components.unitTests.recipe.runAllEditRecipe()
   }

--- a/client/pages/cookbook/cookbook.js
+++ b/client/pages/cookbook/cookbook.js
@@ -1,9 +1,8 @@
 cDI.pages.cookbook = {
   siteHeaderText: "Cookbook",
   init: async () => {
-    await cDI.remote.remoteCall(`/crud/users/r`)
-    // await cDI.remote.asyncGetScript(`js/services/recipeService.js`)
-    // var recipes = await cDI.services.recipe.getAllRecipes()
+    await cDI.remote.asyncGetScript(`js/services/recipeService.js`)
+    var recipes = await cDI.services.recipe.getAllRecipes()
     // console.log()
     // // var favorites = await cDI.components.recipeCard.buildRecipeCardList(recipes)
     // $("#counterTop").append(favorites)

--- a/server/foundation/DICore.js
+++ b/server/foundation/DICore.js
@@ -46,10 +46,14 @@ module.exports = {
       return DI.rh.transformExpectMany(req, data)
     },
     succeed: (res, payload) => {
-      res.json({ status: "s", payload: payload })
+      if (res._headerSent == false){
+        res.json({ status: "s", payload: payload })
+      }
     },
     fail: (res, payload) => {
-      res.json({ status: "e", payload: payload })
+      if (res._headerSent == false){
+        res.json({ status: "e", payload: payload })
+      }
     }
   }
 }

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -3,24 +3,19 @@ var DI = require('../foundation/DICore')
 var userService = require("../services/userService")
 
 module.exports = (router) => {
-
   router.post('/signup', DI.rh.asyncRoute(async (req, res, next) =>
   {
-    try {
-      var newUser = req.body
-      var existingUser = await userService.findByName(newUser.username)
-      if (existingUser.length == 0){
-        var createdUser = await userService.createNew(newUser.username, newUser.password, req.cookies['connect.sid'])
-        if (createdUser.insertId){
-          createdUser = await userService.findById(createdUser.insertId)
-          DI.rh.succeed(res, createdUser)
-        }
+    var newUser = req.body
+    var existingUser = await userService.findByName(newUser.username)
+    if (existingUser.length == 0){
+      var createdUser = await userService.createNew(newUser.username, newUser.password, req.cookies['connect.sid'])
+      if (createdUser.insertId){
+        createdUser = await userService.findById(createdUser.insertId)
+        DI.rh.succeed(res, createdUser)
       }
-      else { DI.rh.fail(res, "Unable to create new user, username is taken.") }
     }
-    catch {
-      DI.rh.fail(res, "Unable to create user, reason unknown.")
-    }
+    else { DI.rh.fail(res, "Unable to create new user, username is taken.") }
+    DI.rh.fail(res, "Unable to create user, reason unknown.")
   }))
   router.post('/login', DI.rh.asyncRoute(async (req, res, next) =>
   {


### PR DESCRIPTION
- curried aliases for dev and unit test logging
- unit tests turn off dev logging to avoid loadComponent messages
- route succeed and fail only fire if headers have not been sent yet
- minor housekeeping

NEXT UP:
- return recipes from route