### PR TITLE
query for existing ingredient

### DIFF
--- a/client/components/big5/unitTests/recipe/utRecipe.js
+++ b/client/components/big5/unitTests/recipe/utRecipe.js
@@ -5,7 +5,7 @@ cDI.components.unitTests.recipe = {
     await cDI.awaitableInput("click", editButton)
 
     var searchSelectPane = await cDI.awaitableInput("click", $(".txtIngFood.Ing0"))
-    await cDI.awaitableInput("click", searchSelectPane.find(".option3"))
+    await cDI.awaitableInput("click", searchSelectPane.find(":contains('parsley'):last"))
 
     var saveButton = recipeCard.find(".shpCheck")
     await cDI.awaitableInput("click", saveButton)

--- a/scripts/mysql/design.sql
+++ b/scripts/mysql/design.sql
@@ -47,11 +47,6 @@ CREATE TABLE recipeTool (
   `toolIndex` int NOT NULL
 );
 
-CREATE TABLE foodCategory (
-  `id` int AUTO_INCREMENT primary key NOT NULL,
-  `name` nvarchar(64) NOT NULL
-);
-
 CREATE TABLE foodType (
   `id` int AUTO_INCREMENT primary key NOT NULL,
   `name` nvarchar(32) NOT NULL,
@@ -60,28 +55,45 @@ CREATE TABLE foodType (
   `plAbbrev` nvarchar(16) NULL
 );
 
-CREATE TABLE prepStyle (
+CREATE TABLE foodVariant (
   `id` int AUTO_INCREMENT primary key NOT NULL,
   `name` nvarchar(32) NOT NULL,
   `abbreviation` nvarchar(32) NOT NULL,
-  `description` nvarchar(16) NOT NULL
-);
-
-CREATE TABLE foodTypeCategory (
-  `id` int AUTO_INCREMENT primary key NOT NULL,
-  `foodTypeId` int NOT NULL,
-  `foodCategoryId` int(64) NOT NULL
+  `description` nvarchar(64) NOT NULL
 );
 
 CREATE TABLE food (
   `id` int AUTO_INCREMENT primary key NOT NULL,
   `foodTypeId` int NOT NULL,
+  `foodVariantId` int NULL
+);
+
+CREATE TABLE foodCategory (
+  `id` int AUTO_INCREMENT primary key NOT NULL,
+  `name` nvarchar(64) NOT NULL
+);
+
+CREATE TABLE categorizedFood (
+  `id` int AUTO_INCREMENT primary key NOT NULL,
+  `foodId` int NOT NULL,
+  `foodCategoryId` int NOT NULL
+);
+
+CREATE TABLE prepStyle (
+  `id` int AUTO_INCREMENT primary key NOT NULL,
+  `name` nvarchar(32) NOT NULL,
+  `description` nvarchar(64) NOT NULL
+);
+
+CREATE TABLE preppedFood (
+  `id` int AUTO_INCREMENT primary key NOT NULL,
+  `foodId` int NOT NULL,
   `prepStyleId` int NULL
 );
 
 CREATE TABLE measureOfFood (
   `id` int AUTO_INCREMENT primary key NOT NULL,
-  `foodId` int NOT NULL,
+  `preppedFoodId` int NULL,
   `UoMId` int NOT NULL
 );
 

--- a/scripts/mysql/sampleData_Base.sql
+++ b/scripts/mysql/sampleData_Base.sql
@@ -31,19 +31,28 @@ INSERT INTO foodType (name, plural) VALUES ('marshmallow', 'marshmallows');
 SET @marshId = LAST_INSERT_ID();
 INSERT INTO foodType (name) VALUES ('cereal');
 SET @cerealId = LAST_INSERT_ID();
+INSERT INTO foodType (name) VALUES ('sausage');
+INSERT INTO foodType (name) VALUES ('parsley');
 
-INSERT INTO food (foodTypeId, prepStyleId) VALUES (@butterId, NULL);
+INSERT INTO food (foodTypeId, foodVariantId) VALUES (@butterId, NULL);
 SET @butterFoodId = LAST_INSERT_ID();
-INSERT INTO food (foodTypeId, prepStyleId) VALUES (@marshId, NULL);
+INSERT INTO food (foodTypeId, foodVariantId) VALUES (@marshId, NULL);
 SET @marshFoodId = LAST_INSERT_ID();
-INSERT INTO food (foodTypeId, prepStyleId) VALUES (@cerealId, NULL);
+INSERT INTO food (foodTypeId, foodVariantId) VALUES (@cerealId, NULL);
 SET @cerealFoodId = LAST_INSERT_ID();
 
-INSERT INTO measureOfFood (foodId, UoMId) VALUES (@butterFoodId, @UoMTbspID);
+INSERT INTO preppedFood (foodId, prepStyleId) VALUES (@butterFoodId, NULL);
+SET @butterPreppedFoodId = LAST_INSERT_ID();
+INSERT INTO preppedFood (foodId, prepStyleId) VALUES (@marshFoodId, NULL);
+SET @marshPreppedFoodId = LAST_INSERT_ID();
+INSERT INTO preppedFood (foodId, prepStyleId) VALUES (@cerealFoodId, NULL);
+SET @cerealPreppedFoodId = LAST_INSERT_ID();
+
+INSERT INTO measureOfFood (preppedFoodId, UoMId) VALUES (@butterPreppedFoodId, @UoMTbspID);
 SET @butterMeasure = LAST_INSERT_ID();
-INSERT INTO measureOfFood (foodId, UoMId) VALUES (@marshFoodId, @UoMCupID);
+INSERT INTO measureOfFood (preppedFoodId, UoMId) VALUES (@marshPreppedFoodId, @UoMCupID);
 SET @marshMeasure = LAST_INSERT_ID();
-INSERT INTO measureOfFood (foodId, UoMId) VALUES (@cerealFoodId, @UoMCupID);
+INSERT INTO measureOfFood (preppedFoodId, UoMId) VALUES (@cerealPreppedFoodId, @UoMCupID);
 SET @cerealMeasure = LAST_INSERT_ID();
 
 INSERT INTO ingredient (measureOfFoodId, quantity) VALUES (@butterMeasure, 3);

--- a/server/models/mysql/ingredientModel.js
+++ b/server/models/mysql/ingredientModel.js
@@ -2,15 +2,28 @@ var DI = require('../../foundation/DICore')
 var db = require('../../foundation/dbLogic')
 
 var ingredientModel = {
-  getAllFoodTypes: async () => {
-    return db.runQuery("SELECT * FROM foodType ORDER BY name LIMIT 100")
-  },
-  findFoodTypeByName: async (name) => {
-    return db.runQuery("SELECT * FROM foodType WHERE name LIKE ? ORDER BY name LIMIT 100", [ `%${name}%` ])
-  },
-  createFoodType: async (name) => {
-    return db.runQuery("INSERT INTO foodType (name) VALUES (?)", [ name ])
-  }
-}
+  getAllFoodTypes: "SELECT * FROM foodType ORDER BY name LIMIT 100",
+  findFoodTypesByName: `SELECT * FROM foodType WHERE name LIKE ? ORDER BY name LIMIT 100`,
+  createFoodType: "INSERT INTO foodType (name) VALUES (?)",
 
+  getUoMsByName: `SELECT * FROM UoM WHERE name LIKE ? ORDER BY name LIMIT 100`,
+
+  ingredientJoins: `
+    recipeIngredient
+    INNER JOIN ingredient ON ingredient.id = recipeIngredient.ingredientId
+    INNER JOIN measureOfFood ON measureOfFood.id = ingredient.measureOfFoodId
+    INNER JOIN UoM ON UoM.id = measureOfFood.UoMId
+    INNER JOIN preppedFood ON preppedFood.id = measureOfFood.preppedFoodId
+    LEFT JOIN prepStyle ON prepStyle.id = preppedFood.prepStyleId
+    INNER JOIN food ON food.id = preppedFood.foodId
+    INNER JOIN foodType ON foodType.id = food.foodTypeId
+    LEFT JOIN foodVariant ON foodVariant.id = food.foodVariantId
+  `,
+}
+ingredientModel.findMeasureOfFood = (variantName, prepStyle) => {
+  return `
+    SELECT * FROM ${ingredientModel.ingredientJoins}
+    WHERE recipeId = ? AND quantity = ? AND UoM.name = ? AND foodType.name = ? AND foodVariant.name ${((variantName == null) ? "IS NULL" : "= ?")} AND prepStyle.name ${((prepStyle == null) ? "IS NULL" : "= ?")}
+  `
+}
 module.exports = ingredientModel

--- a/server/models/mysql/recipeModel.js
+++ b/server/models/mysql/recipeModel.js
@@ -1,5 +1,6 @@
 var DI = require('../../foundation/DICore')
 var db = require('../../foundation/dbLogic')
+var ingredientModel = require("./ingredientModel")
 
 var recipeModel = {
   getAllQuery: `
@@ -20,13 +21,8 @@ var recipeModel = {
     SELECT recipeIngredient.recipeId, recipeIngredient.id,
       quantity,
       UoM.name as UoMName, UoM.abbreviation as UoMAbbreviation,
-      foodType.name, foodType.plural, ingredientIndex as idx
-    FROM recipeIngredient
-    INNER JOIN ingredient ON ingredient.id = recipeIngredient.ingredientId
-    INNER JOIN measureOfFood ON measureOfFood.id = ingredient.measureOfFoodId
-    INNER JOIN UoM ON UoM.id = measureOfFood.UoMId
-    INNER JOIN food ON food.id = measureOfFood.foodId
-    INNER JOIN foodType ON foodType.id = food.foodTypeId
+      foodVariant.name as foodVariant, foodType.name as name, foodType.plural, prepStyle.name as prepStyle, ingredientIndex as idx
+    FROM ${ingredientModel.ingredientJoins}
     WHERE recipeIngredient.recipeId IN (SELECT id FROM recipeIds);
 
     SELECT recipeStep.recipeId, step.id, step.text,

--- a/server/routes/recipeRoutes.js
+++ b/server/routes/recipeRoutes.js
@@ -22,7 +22,7 @@ module.exports = (router) => {
   // }))
   router.post('/crud/foodType/r/', DI.rh.asyncRoute(async (req, res, next) => {
     if (req.body.searchString){
-      var data = await ingredientService.findFoodTypeByName(req.body.searchString)
+      var data = await ingredientService.findFoodTypesByName(req.body.searchString)
     }
     else {
       var data = await ingredientService.getAllFoodTypes()

--- a/server/services/ingredientService.js
+++ b/server/services/ingredientService.js
@@ -3,12 +3,21 @@ var db = require('../foundation/dbLogic')
 
 module.exports = {
   getAllFoodTypes: async (name) => {
-    return await ingredientModel.getAllFoodTypes()
+    return await db.runQuery(ingredientModel.getAllFoodTypes)
   },
-  findFoodTypeByName: async (name) => {
-    return await ingredientModel.findFoodTypeByName(name)
+  findFoodTypesByName: async (name) => {
+    return await db.runQuery(ingredientModel.findFoodTypesByName, [ `%${name}%` ])
   },
   createFoodType: async (name) => {
-    return await ingredientModel.createFoodType(name)
+    return await db.runQuery(ingredientModel.createFoodType, [ name ])
+  },
+
+  getUoMsByName: async (name) => {
+    return await db.runQuery(ingredientModel.getUoMsByName, [ `%${name}%` ])
+  },
+
+  findMeasureOfFood: async(recipeId, quantity, UoMName, variantName, foodTypeName, prepStyleName) => {
+    var paramSet = [ recipeId, quantity, UoMName, foodTypeName, variantName, prepStyleName ]
+    return await db.runQuery(ingredientModel.findMeasureOfFood(variantName, prepStyleName), paramSet)
   }
 }

--- a/server/services/recipeService.js
+++ b/server/services/recipeService.js
@@ -1,5 +1,6 @@
-var recipeModel = require("../models/mysql/recipeModel")
 var db = require('../foundation/dbLogic')
+var recipeModel = require("../models/mysql/recipeModel")
+var ingredientService = require('../services/ingredientService')
 
 module.exports = {
   getAll: async () => {
@@ -8,7 +9,12 @@ module.exports = {
   createNew: () => {
 
   },
-  saveEditedRecipe: (editedRecipe) => {
-    console.log(editedRecipe)
+  saveEditedRecipe: async (editedRecipe) => {
+    for (var x = 0; x < editedRecipe.ingredients.length; x++){
+      var curr = editedRecipe.ingredients[x]
+      console.log(curr)
+      var data = await ingredientService.findMeasureOfFood(curr.recipeId, curr.quantity, curr.UoMName, curr.foodVariant, curr.name, curr.prepStyle)
+      console.log(data)
+    }
   }
 }


### PR DESCRIPTION
- revised db design, prep style is now variant and prep style is what's intended while making the recipe
- unit test now selects parsley explicitly
- models now only contain queries since db.runQuery can be an interface declaration
- separated the joins part of queries for aggregated recipeIngredient data
- save recipe route checks whether each ingredient already exists with all pieces already correct in edited config

NEXT UP:
- experiment with objection