### PR TITLE
set step maps update

### DIFF
--- a/client/assets/css/index2.css
+++ b/client/assets/css/index2.css
@@ -244,6 +244,7 @@ span[contenteditable="true"] {
 }
 .wingedHeader > *:nth-child(1), .wingedHeader > *:nth-child(3)  {
   flex-basis: var(--headerwings);
+  min-width: var(--headerwingmin);
   max-width: var(--headerwingmax);
 }
 .wingedHeader > *:nth-child(2) {
@@ -263,7 +264,10 @@ span[contenteditable="true"] {
 [data-headerwings="20%"] { --headerwings: 20%; }
 [data-headerwings="25%"] { --headerwings: 25%; }
 [data-headerwings="40%"] { --headerwings: 40%; }
+[data-headerwings="200px"] { --headerwings: 200px; }
 
+[data-headerwingmin="200px"] { --headerwingmin: 200px; }
+[data-headerwingmax="250px"] { --headerwingmax: 250px; }
 [data-headerwingmax="300px"] { --headerwingmax: 300px; }
 
 /*#endregion*/

--- a/client/assets/js/services/recipeService.js
+++ b/client/assets/js/services/recipeService.js
@@ -48,6 +48,21 @@ cDI.services.recipe = {
       text: ""
     }
   },
+  newStepMap: (mapType, recipeStepId, barsIndex, recipeIndex) => {
+    return {
+      barsIndex: barsIndex,
+      edited: ["new"],
+      mapType: mapType,
+      recipeIndex: recipeIndex,
+      recipe_stepId: recipeStepId,
+      stepMapId: null,
+      stepMapTypeId: mapType == "tool" ? 1 : 2
+    }
+  },
+  saveStepMap: async (stepMap) => {
+    var retVal = await cDI.remote.remoteCall("/crud/stepMap/u/", { stepMap: stepMap })
+    return retVal
+  },
   save: async (editedRecipe) => {
     var retVal
 

--- a/client/components/big5/header/header.css
+++ b/client/components/big5/header/header.css
@@ -11,18 +11,18 @@
   content: '';
 }
 #iconAuth:before {
-  height: 25%;
-  width: 25%;
+  height: 20%;
+  width: 20%;
   border-radius: 50%;
-  top: 25%;
+  top: 32%;
   content: '';
 }
 #iconAuth:after {
-  width: 50%;
-  height: 25%;
+  width: 40%;
+  height: 20%;
   border-top-left-radius: 110px;
   border-top-right-radius: 110px;
-  top: 45%;
+  top: 50%;
   content: '';
   background-color: var(--clrSecondary);
 }

--- a/client/components/big5/header/header.html
+++ b/client/components/big5/header/header.html
@@ -1,4 +1,4 @@
-<span id="siteHeader" class="wingedHeader algnSpread" data-headerheight="20%" data-headerwings="20%" data-headerwingmax="300px">
+<span id="siteHeader" class="wingedHeader algnSpread" data-headerheight="200px" data-headerwings="20%" data-headerwingmin="200px" data-headerwingmax="250px">
   <span id="hamburgerBox">
     <span class="shpHamburger"></span>
   </span>

--- a/client/components/big5/unitTests/recipe/utRecipe.js
+++ b/client/components/big5/unitTests/recipe/utRecipe.js
@@ -1,8 +1,9 @@
 cDI.components.unitTests.recipe = {
   runAllEditRecipe: async () => {
     var card = $(".recipeCard[recipeid = 1]")
-    await cDI.components.unitTests.recipe.editCard(card)
-
+    // await cDI.components.unitTests.recipe.editCard(card)
+    // await cDI.components.unitTests.recipe.addNewStep(card)
+    // await cDI.components.unitTests.recipe.addNewStep(card)
 
 
     // await cDI.components.unitTests.recipe.saveEdits(card)
@@ -14,7 +15,7 @@ cDI.components.unitTests.recipe = {
 
   //#region ingredients
   addNewIng: async (card) => {
-    await cDI.awaitableInput("click", card.find(".cardIngs > span > .shpPlus"))
+    await cDI.awaitableInput("click", card.find(".cardIngs > .ingTitle > .btnIcon > .shpPlus").parent())
   },
   alterIngredient: async (card, index, prop, val) => {
     if (prop == "Quantity"){
@@ -56,7 +57,7 @@ cDI.components.unitTests.recipe = {
 
   //#region steps
   addNewStep: async (card) => {
-    return await cDI.awaitableInput("click", card.find(".cardSteps > span > .shpPlus"))
+    return await cDI.awaitableInput("click", card.find(".cardSteps > .stepTitle > .btnIcon > .shpPlus").parent())
   },
   alterStep: async (card, stepIndex, textVal) => {
     card.find(`.txtStep.step${stepIndex}`).html(textVal)

--- a/client/components/genericWidgets/modal/modal.js
+++ b/client/components/genericWidgets/modal/modal.js
@@ -2,11 +2,16 @@ cDI.components.modal = {
   init: () => {
 
   },
+  justDrawCurtain: (target) => {
+    target.prepend(`<span class="modalCurtain"></span>`)
+  },
   drawCurtain: async (params = {}) => {
     var target = params.target || $("html")
     var content = params.content || ""
     var maximizeDialog = params.maximizeDialog || false
-    target.prepend(`<span class="modalCurtain">${content}</span>`)
+
+    cDI.components.modal.justDrawCurtain(target)
+    target.find(" > .modalCurtain").html(content)
     var curtain = target.find(".modalCurtain")
 
     if (maximizeDialog){
@@ -32,7 +37,7 @@ cDI.components.modal = {
     content.addClass("max")
   },
   clickToModal: async (elem, compPath, compName, fn, maximizeDialog = false) => {
-    await cDI.addAwaitableInput("click", elem, async (e) => {
+    cDI.addAwaitableInput("click", elem, async (e) => {
       var tmpContainer = $("<span id='modalTemp'></span>")
       var contentDI = await cDI.remote.loadComponent(tmpContainer, compPath, compName)
       var content = tmpContainer.html()

--- a/client/components/projectWidgets/recipeCard/ingredientPane.js
+++ b/client/components/projectWidgets/recipeCard/ingredientPane.js
@@ -9,14 +9,14 @@ cDI.components.recipeCard.ingredientPane = {
     var sorted = recipe.ingredients.sort((a, b) => a.ingredientIndex < b.ingredientIndex)
 
     card.find(".cardIngs").append(`
-      <span class="rows autoH algnSC">
+      <span class="ingTitle rows autoH algnSC">
         ${editMode ? `
         <span class="btnIcon" data-btnsize="55">
           <span class="shpPlus"></span>
         </span>` : ``}
         <span class="autoH autoW bold ingPaneTitle">Ingredients</span>
       </span>`)
-    cDI.addAwaitableInput("click", card.find(".shpPlus"), (e) => {
+    cDI.addAwaitableInput("click", card.find(".shpPlus").parent(), (e) => {
       var newIng = cDI.services.recipe.newIngredient(card.data("recipe").id, sorted[sorted.length - 1].ingredientIndex + 1)
       card.data("editedrecipe").ingredients.push(newIng)
       cDI.components.recipeCard.ingredientPane.createIngPane(card, 1)
@@ -26,7 +26,7 @@ cDI.components.recipeCard.ingredientPane = {
       ingLine += sorted[sorted.length - 1].ingredientIndex != ingredient.ingredientIndex ? `<span class="rule horiz slim"></span>` : ``
       card.find(".cardIngs").append(ingLine)
       if (editMode){
-        var line = card.find(`.cardIngs > .cardIngredient[data-ingredientindex=${ingredient.ingredientIndex}]`)
+        var line = card.find(`.cardIngs > .cardIngredient[ingredientIndex=${ingredient.ingredientIndex}]`)
 
         var txtIngQuantity = line.find(`.txtIngQuantity.Ing${ingredient.ingredientIndex}`)
         cDI.addAwaitableInput("keyup", txtIngQuantity, async (e) => {
@@ -40,7 +40,7 @@ cDI.components.recipeCard.ingredientPane = {
         cDI.components.recipeCard.ingredientPane.addClick(txtIngSubstance, "substance", "name")
 
         cDI.addAwaitableInput("click", line.find(".shpMinus").parent(), async (e) => {
-          await cDI.components.recipeCard.ingredientPane.acceptRemoval(card, $(e.target).closest(".cardIngredient").data("ingredientindex"))
+          await cDI.components.recipeCard.ingredientPane.acceptRemoval(card, $(e.target).closest(".cardIngredient").attr("ingredientIndex"))
         })
       }
     })
@@ -63,14 +63,14 @@ cDI.components.recipeCard.ingredientPane = {
     var UoMName = !editMode && ingredient.UoMAbbr ? UoMName = ingredient.UoMAbbr : ingredient.UoMName
 
     var ing = `
-      <span class="cardIngredient leftCopy rows autoH algnSC fauxrder" data-ingredientindex="${ingIdx}">
+      <span class="cardIngredient leftCopy rows autoH algnSC rounded" ingredientIndex="${ingIdx}">
         <span class="ingIdx absCen" style="flex-basis:50px;">-&nbsp;</span>
     `
     if (editMode){
       ing += `<span class="wrap autoH algnSC">`
-        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngQuantity Ing${ingIdx} autoW autoH rounded" data-ingredientprop="quantity">${(new Fraction(ingredient.ingredientQuantity)).toFraction()}</span></span>`
-        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngUoM Ing${ingIdx} autoW autoH rounded" data-ingredientprop="UoM">${UoMName ? UoMName : ""}</span></span>`
-        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngSubstance Ing${ingIdx} autoW autoH rounded" data-ingredientprop="substance">${ingName ? ingName : ""}</span></span>`
+        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngQuantity Ing${ingIdx} autoW autoH rounded" ingredientProp="quantity">${(new Fraction(ingredient.ingredientQuantity)).toFraction()}</span></span>`
+        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngUoM Ing${ingIdx} autoW autoH rounded" ingredientProp="UoM">${UoMName ? UoMName : ""}</span></span>`
+        ing += `<span class="fauxrder autoW autoH"><span contenteditable="true" class="txtIngSubstance Ing${ingIdx} autoW autoH rounded" ingredientProp="substance">${ingName ? ingName : ""}</span></span>`
       ing += `</span>`
       ing += `<span class="btnIcon" data-btnsize="55">
                 <span class="shpMinus"></span>
@@ -88,8 +88,8 @@ cDI.components.recipeCard.ingredientPane = {
     var card = input.closest(".recipeCard")
     var origRecipe = card.data("recipe")
     var editedRecipe = card.data("editedrecipe")
-    var ingredientIndex = input.closest(".cardIngredient").data("ingredientindex")
-    var ingredientProp = input.data("ingredientprop")
+    var ingredientIndex = input.closest(".cardIngredient").attr("ingredientIndex")
+    var ingredientProp = input.attr("ingredientProp")
 
     var origIng = origRecipe.ingredients.find(x => x.ingredientIndex == ingredientIndex)
     var editedIng = editedRecipe.ingredients.find(x => x.ingredientIndex == ingredientIndex)

--- a/client/components/projectWidgets/recipeCard/recipeCard.css
+++ b/client/components/projectWidgets/recipeCard/recipeCard.css
@@ -8,6 +8,7 @@
 .cardIngs, .cardSteps {
   max-height: 50%;
   padding: 15px 5px;
+  box-shadow: 0px 0px 5px 2px black;
 }
 
 .ingPaneTitle, .stepPaneTitle {
@@ -16,13 +17,12 @@
 
 .cardIngredient, .cardStep { padding: 5px 25px; }
 
-.stepIngredient, .stepTool {
+.stepIngredientMap, .stepToolMap {
   padding: 0px 5px;
   margin: 0px 5px;
 }
-.stepIngredient { background-color: var(--clrPrimary); }
-
-.stepTool { background-color: var(--clrSecondary); }
+.stepIngredientMap { background-color: var(--clrPrimary); }
+.stepToolMap { background-color: var(--clrSecondary); }
 
 .txtIngQuantity, .txtIngUoM, .txtIngSubstance { flex-basis: auto; }
 .txtIngUoM, .txtIngSubstance { min-width: 100px; }
@@ -33,4 +33,18 @@
 
 .recipeEdit {
   height:100%;
+}
+
+.settingStepMap {
+  z-index: 10000
+}
+
+.settingStepMap > .selector {
+  background-color: rgba(220, 250, 220, .4);
+  position: absolute;
+  z-index: 10001
+}
+
+.selector.selected {
+  background-color: rgba(220, 220, 0, .4) !important;
 }

--- a/client/components/projectWidgets/recipeCard/recipeCard.html
+++ b/client/components/projectWidgets/recipeCard/recipeCard.html
@@ -8,7 +8,7 @@
     <span class="recipeName subheader"></span>
     <span class="recipeEdit row"></span>
   </span>
-  <span class="cardIngs cols autoH algnSX allowOverflow shyScroll"></span>
+  <span class="cardIngs cols autoH algnSX rounded allowOverflow shyScroll"></span>
   <span class="rule horiz"></span>
-  <span class="cardSteps cols autoH algnSX allowOverflow shyScroll"></span>
+  <span class="cardSteps cols autoH algnSX rounded allowOverflow shyScroll"></span>
 </span>

--- a/client/components/projectWidgets/recipeCard/recipeCard.js
+++ b/client/components/projectWidgets/recipeCard/recipeCard.js
@@ -64,7 +64,8 @@ cDI.components.recipeCard = {
   saveChanges: async (card) => {
     var res = await cDI.services.recipe.save(card.data("editedrecipe"))
     if (res.status == "s") {
-      card.data("recipe", card.data("editedrecipe"))
+      console.log(res)
+      card.data("recipe", res.payload)
     }
     else {
       console.log(res)

--- a/scripts/mysql/graphSampleData_Base.sql
+++ b/scripts/mysql/graphSampleData_Base.sql
@@ -115,13 +115,13 @@ SET @stepMapType0 = LAST_INSERT_ID();
 INSERT INTO stepMapType (mapType) VALUES ('ingredient');
 SET @stepMapType1 = LAST_INSERT_ID();
 
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@recipeStep0Id, @stepMapType0, 0, 0);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@recipeStep0Id, @stepMapType1, 0, 0);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@recipeStep1Id, @stepMapType0, 0, 0);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@recipeStep1Id, @stepMapType1, 0, 1);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@recipeStep2Id, @stepMapType1, 0, 2);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@recipeStep0Id, @stepMapType0, 0, 0);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@recipeStep0Id, @stepMapType1, 0, 0);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@recipeStep1Id, @stepMapType0, 0, 0);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@recipeStep1Id, @stepMapType1, 0, 1);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@recipeStep2Id, @stepMapType1, 0, 2);
 
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@ICrecipeStep0Id, @stepMapType1, 0, 0);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 0, 0);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 1, 1);
-INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, stepIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 2, 2);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@ICrecipeStep0Id, @stepMapType1, 0, 0);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 0, 0);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 1, 1);
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex) VALUES (@ICrecipeStep1Id, @stepMapType1, 2, 2);

--- a/server/models/recipe/tool/recipe_toolModel.js
+++ b/server/models/recipe/tool/recipe_toolModel.js
@@ -1,5 +1,5 @@
 module.exports = {
   tableName: "recipe_tool",
   fields: ["recipeId", "toolIndex"],
-  aliases: ["recipeId", "toolIdx"]
+  aliases: ["recipeId", "toolIndex"]
 }

--- a/server/queries/recipe/recipeQueries.js
+++ b/server/queries/recipe/recipeQueries.js
@@ -29,7 +29,7 @@ recipeQueries.getById = (setName) => {
   return `
 ${ss.addSet(setName || "tmp_recipe").body(`
 ${recipeQueries.selectBase}
-WHERE recipe.id LIKE ?
+WHERE recipe.id = ?
 `)}
 `
 }

--- a/server/queries/recipe/step/stepObjQueries.js
+++ b/server/queries/recipe/step/stepObjQueries.js
@@ -1,17 +1,42 @@
 var ss = require('../../../utils/sqlSnippets')
 var stepModels = require('../../../models/recipe/step/stepObjModel')
 
-module.exports = {
-  getMapsForStepSet: (stepSetName, setName) => {
-    return `
+var stepObjQueries = {}
+stepObjQueries.upsert = (qb, text) => {
+  var query = `
+SELECT @stepId:=id FROM step WHERE text = ?;
+INSERT INTO step (text)
+  SELECT ? WHERE @stepId IS NULL;
+SET @stepId = (SELECT IFNULL(@stepId, LAST_INSERT_ID()));
+`
+  qb.insertQuery(query)
+  qb.insertNonNullParams(text, text)
+}
+stepObjQueries.getMapsForStepSet = (stepSetName, setName) => {
+  return `
 ${ss.addSet(setName || "tmp_stepMap").body(`
-  SELECT
-    ${ss.projections(stepModels.stepMapType)},
-    ${ss.projections(stepModels.stepMap)}
-  FROM ${stepModels.stepMap.tableName}
-  ${ss.join(stepModels.stepMap.tableName, stepModels.stepMapType.tableName)}
-  WHERE ${stepModels.stepMap.tableName}.recipeStepId IN (SELECT recipe_stepId FROM ${stepSetName})
+SELECT
+  ${ss.projections(stepModels.stepMapType)},
+  ${ss.projections(stepModels.stepMap)}
+FROM ${stepModels.stepMap.tableName}
+${ss.join(stepModels.stepMap.tableName, stepModels.stepMapType.tableName)}
+WHERE ${stepModels.stepMap.tableName}.recipeStepId IN (SELECT recipe_stepId FROM ${stepSetName})
 `)}
 `
-  }
 }
+stepObjQueries.upsertStepMap = (qb, recipe_stepId, stepMapTypeId, barsIndex, recipeIndex) => {
+  var query = `
+SELECT @stepMapId:=id FROM stepMap WHERE recipeStepId = ? AND stepMapTypeId = ? AND barsIndex = ?;
+INSERT INTO stepMap (recipeStepId, stepMapTypeId, barsIndex, recipeIndex)
+  SELECT ?, ?, ?, ? WHERE @stepMapId IS NULL;
+SET @stepMapId = (SELECT IFNULL(@stepMapId, LAST_INSERT_ID()));
+UPDATE stepMap SET recipeIndex = ? WHERE id = @stepMapId
+
+`
+qb.insertQuery(query)
+qb.insertParams(recipe_stepId, stepMapTypeId, barsIndex)
+qb.insertParams(recipe_stepId, stepMapTypeId, barsIndex, recipeIndex)
+qb.insertParam(recipeIndex)
+}
+
+module.exports = stepObjQueries

--- a/server/routes/recipeRoutes.js
+++ b/server/routes/recipeRoutes.js
@@ -1,6 +1,7 @@
 var db = require('../foundation/dbLogic')
 var recipeService = require('../services/recipeService')
 var ingredientService = require('../services/ingredientService')
+var stepService = require('../services/stepService')
 var DI = require('../foundation/DICore')
 
 module.exports = (router) => {
@@ -9,8 +10,8 @@ module.exports = (router) => {
     DI.rh.succeed(res, recipes)
   }))
   router.post('/crud/recipe/u/', DI.rh.asyncRoute(async (req, res, next) => {
-    var recipes = await recipeService.saveEditedRecipe(req.body.editedRecipe)
-    DI.rh.succeed(res, `Changes saved for recipe ${req.body.editedRecipe.id}`)
+    var updatedRecipe = await recipeService.saveEditedRecipe(req.body.editedRecipe)
+    DI.rh.succeed(res, updatedRecipe)
   }))
 
   router.post('/crud/UoM/c/', DI.rh.asyncRoute(async (req, res, next) => {
@@ -43,5 +44,16 @@ module.exports = (router) => {
       var data = await ingredientService.getAllSubstances()
     }
     DI.rh.succeed(res, data)
+  }))
+
+  router.post('/crud/stepMap/u/', DI.rh.asyncRoute(async (req, res, next) => {
+    if (req.body.stepMap){
+      console.log(req.body.stepMap)
+      var data = await stepService.upsertStepMap(req.body.stepMap)
+      DI.rh.succeed(res, data)
+    }
+    else {
+      DI.rh.fail(res, "No step map supplied")
+    }
   }))
 }

--- a/server/services/recipeService.js
+++ b/server/services/recipeService.js
@@ -29,7 +29,7 @@ recipeService.getByName = async (name) => {
   return recipeService.parseObj(data)
 }
 recipeService.getById = async (id) => {
-  var data = await db.runQuery(recipeObjQueries.getById(), [`%${id}%`])
+  var data = await db.runQuery(recipeObjQueries.getById(), [id])
   return recipeService.parseObj(data)[0]
 }
 recipeService.saveEditedRecipe = async (editedRecipe) => {
@@ -81,6 +81,7 @@ recipeService.saveEditedRecipe = async (editedRecipe) => {
     // console.log(qb.printRunnable())
     var res = await qb.run()
   }
+  return await recipeService.getById(editedRecipe.id)
 }
 
 module.exports = recipeService

--- a/server/services/stepService.js
+++ b/server/services/stepService.js
@@ -1,9 +1,16 @@
 var db = require('../foundation/dbLogic')
+var queryBuilder = require('../utils/queryBuilder')
+var stepObjQueries = require("../queries/recipe/step/stepObjQueries")
 var stepQueries = require("../queries/recipe/step/stepQueries")
 
 var stepService = {}
 stepService.upsert = async (qb, text) => {
   return stepQueries.upsert(qb, text)
 }
-
+stepService.upsertStepMap = async (stepMap) => {
+  var qb = queryBuilder.new()
+  stepObjQueries.upsertStepMap(qb, stepMap.recipe_stepId, stepMap.stepMapTypeId, stepMap.barsIndex, stepMap.recipeIndex)
+  console.log(qb.printRunnable())
+  return await qb.run()
+}
 module.exports = stepService


### PR DESCRIPTION
- fixed add step and add ingredient buttons
- can now set step maps in display mode
- style adjustments for mobile
- modals can now just draw a curtain allowing an element to be highlighted with z-index
- changed ingredient data- values with attrs where possible
- saving recipe now returns full updated recipe
- fixed getRecipeById

NEXT UP:
- add a new step, save, and set it's maps without reloading page
- add a new step, save, and remove without reloading page