### PR TITLE
bugfix - stepMap selection modal

### DIFF
--- a/client/components/genericWidgets/modal/modal.js
+++ b/client/components/genericWidgets/modal/modal.js
@@ -1,6 +1,6 @@
 cDI.components.modal = {
   init: (params = {}) => {
-    var target = params.target || $("html")
+    var target = params.target || $("body")
     var content = params.content || ""
     var maximizeDialog = params.maximizeDialog || false
 
@@ -33,7 +33,7 @@ cDI.components.modal = {
     target.remove()
   },
   maximizeDialog: (target) => {
-    target = target || $("html")
+    target = target || $("body")
     var content = target.find(".modalCurtain").last()
     content.addClass("max")
   },

--- a/client/components/projectWidgets/recipeCard/ingredientPane.js
+++ b/client/components/projectWidgets/recipeCard/ingredientPane.js
@@ -141,6 +141,7 @@ cDI.components.recipeCard.ingredientPane = {
     if (editedIng.edited.length == 0) { delete editedIng.edited }
 
     await cDI.components.recipeCard.stepPane.reload(card, 1)
+    console.log(editedRecipe)
   },
   acceptRemoval: async (card, index) => {
     var removedIng = card.data("editedrecipe").ingredients.find(x => x.ingredientIndex == index)

--- a/client/components/projectWidgets/recipeCard/recipeCard.js
+++ b/client/components/projectWidgets/recipeCard/recipeCard.js
@@ -29,6 +29,7 @@ cDI.components.recipeCard = {
     await cDI.components.recipeCard.buildRecipeCard($("#counterTop > .recipeCard").last(), recipe)
   },
   buildRecipeCard: async (card, recipe) => {
+    var editsExist = cDI.components.recipeCard.editsExist(card)
     card.find(".recipeName").html(recipe.name)
     card.data("recipe", recipe)
     card.attr("recipeId", recipe["id"])
@@ -75,8 +76,6 @@ cDI.components.recipeCard = {
       })
     }
   },
-//#endregion
-
   saveChanges: async (card) => {
     var res = await cDI.services.recipe.save(card.data("editedrecipe"))
     if (res.status == "s") {
@@ -86,5 +85,24 @@ cDI.components.recipeCard = {
     }
     await cDI.components.recipeCard.setEditMode(card, 0)
     return res
+  },
+//#endregion
+
+//#region utils
+  editsExist: (card) => {
+    var editedRecipe = card.data("editedrecipe")
+    if (editedRecipe) {
+      return editedRecipe.ingredients.filter(x => x.edited && x.edited.length > 0).length > 0
+    }
+    return false
+  },
+  getIngredients: (card) => {
+    var recipe = card.data("editedrecipe") ? card.data("editedrecipe") : card.data("recipe")
+    return recipe.ingredients
+  },
+  getSteps: (card) => {
+    var recipe = card.data("editedrecipe") ? card.data("editedrecipe") : card.data("recipe")
+    return recipe.steps
   }
+//#endregion
 }

--- a/client/components/projectWidgets/recipeCard/stepPane.js
+++ b/client/components/projectWidgets/recipeCard/stepPane.js
@@ -1,4 +1,5 @@
 cDI.components.recipeCard.stepPane = {
+//#region main build functions
   reload: async (card, editMode) => {
     return cDI.utils.wrapInPromise((f) => {
       var stepsPane = card.find(".cardSteps")
@@ -12,8 +13,10 @@ cDI.components.recipeCard.stepPane = {
     })
   },
   build: (card, editMode) => {
+    var editsExist = cDI.components.recipeCard.editsExist(card)
+    console.log(editsExist)
     var stepsPane = card.find(".cardSteps")
-    var recipe = editMode ? card.data("editedrecipe") : card.data("recipe")
+    var recipe = editsExist ? card.data("editedrecipe") : card.data("recipe")
     var paneHtml = ``
     var sorted = recipe.steps.sort((a, b) => a.stepIndex < b.stepIndex)
 
@@ -31,12 +34,12 @@ cDI.components.recipeCard.stepPane = {
       await cDI.components.recipeCard.stepPane.reload(card, 1)
     })
     sorted.filter(x => !x.edited || !x.edited.includes("removed")).forEach(step => {
-      var stepHTML = cDI.components.recipeCard.stepPane.createStepLine(recipe, step, editMode)
+      var stepHTML = cDI.components.recipeCard.stepPane.createStepLine(recipe, step, editMode, editsExist)
       stepsPane.append(stepHTML)
     });
     cDI.components.recipeCard.stepPane.addEditEvents(card, editMode)
   },
-  createStepLine: (recipe, step, editMode) => {
+  createStepLine: (recipe, step, editMode, editsExist) => {
     var stepHTML = `
       <span class="cardStep rows autoH algnSS rounded" stepIndex="${step.stepIndex}" recipe_stepId="${step.recipe_stepId}">
         <span class="stepIdx autoH noShrink" style="flex-basis: 50px;">${step.stepIndex}.&nbsp;</span>
@@ -108,6 +111,9 @@ cDI.components.recipeCard.stepPane = {
           }
           await cDI.components.recipeCard.stepPane.reload(card)
           card.find(`.cardIngredient > .selector`).remove()
+          card.find(`.cardIngs`).removeClass("liftAboveCurtain")
+          card.find(`.cardIngredient`).removeClass("whiteBG")
+          card.find(`.cardSteps`).removeClass("liftAboveCurtain")
           await cDI.components.modal.raiseCurtain(card)
         })
       })
@@ -117,6 +123,9 @@ cDI.components.recipeCard.stepPane = {
       // })
     }
   },
+//#endregion
+
+//#region fill out step text
   addMapsToStepText: (stepText, maps, ingredients, tools) => {
     if (stepText.indexOf("{i") != -1) { stepText = cDI.components.recipeCard.stepPane.addIngredientsToStep(ingredients, stepText, maps.filter(x => x.mapType == "ingredient")) }
     if (stepText.indexOf("{t") != -1) { stepText = cDI.components.recipeCard.stepPane.addToolsToStep(tools, stepText, maps.filter(x => x.mapType == "tool")) }
@@ -150,6 +159,9 @@ cDI.components.recipeCard.stepPane = {
     }
     return stepText
   },
+//#endregion
+
+//#region accept changes
   acceptStepChange: (card, input) => {
     var stepIndex = input.attr("stepIndex")
     var editedStep = card.data("editedrecipe").steps.find(x => x.stepIndex == stepIndex)
@@ -185,5 +197,5 @@ cDI.components.recipeCard.stepPane = {
     });
     await cDI.components.recipeCard.stepPane.reload(card, 1)
   }
-
+//#endregion
 }

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,3 @@
-- setting stepMap then changing ingredient causes bugged modal
 - recipe name should show asterisk when there are unsaved changes
 - add new ingredient field via searchSelect should select the value
 


### PR DESCRIPTION
- bugfix for step map selection modal overlaying ingredient change modal if attempted in that order
- default modals onto body instead of html
- add util functions to recipeCard (editsExist, getIngredients, getSteps)
- build stepPane now uses edited recipe when there are changes

NEXT UP:
- display asterisk when recipeCard has unsaved edits