### PR TITLE
header font size and shyScroll layout update

### DIFF
--- a/client/assets/css/index.css
+++ b/client/assets/css/index.css
@@ -144,12 +144,12 @@ span[contenteditable="true"] {
   overflow-y: scroll;
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  justify-content: start;
 }
 .shyScroll::-webkit-scrollbar { /* WebKit */
    width: 0;
    height: 0;
 }
-.shyScroll { flex-shrink: 0; }
 .shyScroll > * { flex-shrink: 0; }
 
 .noShadow { box-shadow: 0px 0px; }
@@ -175,6 +175,12 @@ span[contenteditable="true"] {
   font-style: italic;
   font-weight: normal;
 }
+.respFontLg {
+  font-size: 5vw;
+}
+.respFontSm {
+  font-size: 4vw;
+}
 .byline {
   font-family: var(--subheaderFont);
   font-style: italic;
@@ -182,6 +188,12 @@ span[contenteditable="true"] {
 .noUnderline { text-decoration: none !important; }
 .bold { font-weight: bold; }
 .italic { font-style: italic; }
+p.linebreak {
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+}
  /*#endregion*/
 
 /*#region rule bars*/

--- a/client/components/big5/contentMain/contentMain.js
+++ b/client/components/big5/contentMain/contentMain.js
@@ -1,6 +1,6 @@
 cDI.components.contentMain = {
   init: async () => {
-    $("body").append(`<span id="contentMain"></span>`)
+    $("body").append(`<span id="contentMain" class="shyScroll algnSX"></span>`)
   },
   loadPage: async (name) => {
     $("#contentMain").empty()

--- a/client/components/big5/header/header.js
+++ b/client/components/big5/header/header.js
@@ -5,7 +5,12 @@ cDI.components.header = {
         <span id="hamburgerBox">
           <span class="shpHamburger"></span>
         </span>
-        <span id="siteHeaderText" class="header"></span>
+        <span id="siteHeaderText" class="header">
+          <span class="cols">
+            <span class="header respFontLg">Code for the Fences</span>
+            <span id="pageName" class="iSubheader algnSX respFontSm"></span>
+          </span>
+        </span>
         <span id="authBox">
           <span id="iconAuth"></span>
         </span>
@@ -15,7 +20,7 @@ cDI.components.header = {
     await cDI.components.header.strapHeaderHamburger()
   },
   setHeaderText: (text) => {
-    $("#siteHeaderText").html(text)
+    $("#pageName").html(text)
   },
   strapAuthButton: async () => {
     if ($("#accountDash") || $("#signupLoginBox")) { cDI.components.modal.raiseCurtain() }
@@ -50,6 +55,9 @@ cDI.components.header = {
         <span class="mainMenuTitle autoH header">Main Menu</span>
           <span class="autoH algnSX">
           <span class="fauxrder">
+            <span id="mainNavAbout" class="btnStd subheader" style="flex-basis: 100px;">About</span>
+          </span>
+          <span class="fauxrder">
             <span id="mainNavBlog" class="btnStd subheader" style="flex-basis: 100px;">Blog</span>
           </span>
           <span class="fauxrder">
@@ -67,7 +75,7 @@ cDI.components.header = {
     cDI.components.header.addMainNavClick(pane, $("#mainNavBlog"), '/blog')
     cDI.components.header.addMainNavClick(pane, $("#mainNavCookbook"), '/cookbook')
     cDI.components.header.addMainNavClick(pane, $("#mainNavDarkRoom"), '/darkRoom')
-    cDI.components.header.addMainNavClick(pane, $("#mainNavBudget"), '/budget')
+    cDI.components.header.addMainNavClick(pane, $("#mainNavAbout"), '/about')
     await cDI.components.drawerPane.openDrawerPane(pane)
   },
   addMainNavClick: (pane, elem, routePath) => {

--- a/client/components/projectWidgets/recipeCard/ingredientPane.js
+++ b/client/components/projectWidgets/recipeCard/ingredientPane.js
@@ -14,7 +14,7 @@ cDI.components.recipeCard.ingredientPane = {
         <span class="btnIcon" data-btnsize="55">
           <span class="shpPlus"></span>
         </span>` : ``}
-        <span class="autoH autoW bold ingPaneTitle">Ingredients</span>
+        <span class="autoH autoW bold ingPaneTitle subheader respFontSm">Ingredients</span>
       </span>`)
     cDI.addAwaitableInput("click", card.find(".ingTitle > .btnIcon > .shpPlus").parent(), async e => {
       var parentCard = $(e.target).closest(".recipeCard")

--- a/client/components/projectWidgets/recipeCard/recipeCard.css
+++ b/client/components/projectWidgets/recipeCard/recipeCard.css
@@ -3,6 +3,9 @@
   border: solid thick black;
   margin: 5px 0px;
 }
+.recipeName {
+  padding: 5px;
+}
 .cardIngs { margin-bottom: 10px; }
 .cardSteps { margin-top: 10px; }
 .cardIngs, .cardSteps {

--- a/client/components/projectWidgets/recipeCard/recipeCard.js
+++ b/client/components/projectWidgets/recipeCard/recipeCard.js
@@ -12,13 +12,13 @@ cDI.components.recipeCard = {
   appendRecipeCard: async (counterTop, recipe) => {
     var recipeCard = `
     <span class="recipeCard autoH roundedWide algnSX">
-      <span class="wingedHeader algnSpread" data-headerheight="120px" data-headerwings="20%">
+      <span class="wingedHeader algnSpread autoH"  data-headerwings="20%">
         <span class="recipeStats">
           <span class="recipeTime"></span>
           <span class="recipeServings"></span>
           <span class="recipeCalories"></span>
         </span>
-        <span class="recipeName subheader"></span>
+        <span class="recipeName header respFontLg"></span>
         <span class="recipeEdit row"></span>
       </span>
       <span class="cardIngs autoH rounded fauxrder algnSX shyScroll"></span>

--- a/client/components/projectWidgets/recipeCard/stepPane.js
+++ b/client/components/projectWidgets/recipeCard/stepPane.js
@@ -25,7 +25,7 @@ cDI.components.recipeCard.stepPane = {
         <span class="btnIcon" data-btnsize=55>
           <span class="shpPlus"></span>
         </span>` : ""}
-        <span class="autoH autoW bold stepPaneTitle">Steps</span>
+        <span class="autoH autoW bold stepPaneTitle subheader respFontSm">Steps</span>
       </span>`)
     cDI.addAwaitableInput("click", card.find(".stepTitle > .btnIcon > .shpPlus").parent(), async (e) => {
       var newStep = cDI.services.recipe.newStep(card.data("recipe").id, sorted[sorted.length - 1].stepIndex + 1)

--- a/client/pages/about/about.html
+++ b/client/pages/about/about.html
@@ -1,0 +1,22 @@
+<span class="autoH">
+  <p class="linebreak"><b>Software is eating the world, and it is delicious.</b></p>
+  <p class="linebreak"><i>Updated 2021-09-20</i></p>
+  <p>Hello, welcome to Code for the Fences!</p>
+  <p>
+    My name is Devin Downer and this site is a somewhat random collection of ideas I've had.
+    My original goal was to host my own suite of dogfood tools such as a budget and cookbook.
+  </p>
+  <p>
+    Since then I've been distracted by experimenting with architectural patterns, writing a
+  componentized front-end library, conceptualizing a fully-decentralized blockchain web app with
+  a payload of it's own git repo, brainstorming HTML/JS/CSS games, and various other
+  non-demoable endeavors.
+  </p>
+  <p>
+    Finally I have the foundation I need to create the functionality that makes my own life easier,
+    and am excited to have something I'm proud to show off.
+  </p>
+  <p>
+    As of today I consider the existing features to be in development/alpha testing.
+  </p>
+</span>

--- a/client/pages/about/about.js
+++ b/client/pages/about/about.js
@@ -1,0 +1,3 @@
+cDI.pages.about = {
+  siteHeaderText: `About`,
+}

--- a/client/pages/blog/blog.js
+++ b/client/pages/blog/blog.js
@@ -1,5 +1,5 @@
 cDI.pages.blog = {
-  siteHeaderText: `<span class="cols"><span class="header">Code for the Fences</span><span class="iSubheader">Software is eating the world, and it is delicious</span>`,
+  siteHeaderText: `Blog`,
   init: async () => {
     await cDI.remote.asyncGetScript(`js/services/blogService.js`)
     await cDI.pages.blog.buildPostList()

--- a/project-management/todo.txt
+++ b/project-management/todo.txt
@@ -1,4 +1,6 @@
+Minor bugs and features:
 - wire up add buttons for foodVariant and prepStyle
+- adding new searchSelect value should automatically select as well
 - "bitter marshmallows" creates erroneous div, removing space
 - bug adding new prepStyles
 - fix shyScroll of searchSelect
@@ -9,5 +11,4 @@
 Big Picture:
 - lead cap manager portfolio demo
 - budget page
-- about the site page
 - unit test GUI


### PR DESCRIPTION
- + about page and main nav item
- always show the CFTF header
- + responsive font classes
- + linebreak class that removes margins from <p>
- shyScroll needs to align to start to avoid content hiding above top of shyScroll containers
- shyScroll containers themselves must be able to shrink
- site subheader is now essentially page name
- give padding to recipeName
- recipeCard header now autoH, which requires removing data-headerheight

NEXT UP:
- minor bugs and features